### PR TITLE
Handle expired auth tokens with auto logout

### DIFF
--- a/client/client/src/context/AuthContext.jsx
+++ b/client/client/src/context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { jwtDecode } from 'jwt-decode'
 import api from '../lib/api'
 
@@ -8,17 +8,45 @@ export const useAuth = () => useContext(AuthCtx)
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [hydrated, setHydrated] = useState(false) // <-- NEW
+  const logoutTimer = useRef(null)
+
+  const clearLogoutTimer = () => {
+    if (logoutTimer.current) {
+      clearTimeout(logoutTimer.current)
+      logoutTimer.current = null
+    }
+  }
+
+  const logout = () => {
+    localStorage.removeItem('token')
+    localStorage.removeItem('user_name')
+    clearLogoutTimer()
+    setUser(null)
+  }
+
+  const scheduleLogout = (exp) => {
+    const delay = exp * 1000 - Date.now()
+    if (delay <= 0) {
+      logout()
+    } else {
+      logoutTimer.current = setTimeout(logout, delay)
+    }
+  }
 
   useEffect(() => {
     const token = localStorage.getItem('token')
     if (token) {
       try {
         const payload = jwtDecode(token)
-        const name = localStorage.getItem('user_name') || null
-        setUser({ id: payload.user_id, role: payload.role, store_id: payload.store_id, name })
+        if (payload.exp && payload.exp < Date.now() / 1000) {
+          logout()
+        } else {
+          const name = localStorage.getItem('user_name') || null
+          setUser({ id: payload.user_id, role: payload.role, store_id: payload.store_id, name })
+          if (payload.exp) scheduleLogout(payload.exp)
+        }
       } catch {
-        localStorage.removeItem('token')
-        localStorage.removeItem('user_name')
+        logout()
       }
     }
     setHydrated(true) // <-- initial check finished
@@ -30,15 +58,10 @@ export function AuthProvider({ children }) {
     if (data?.user?.name) localStorage.setItem('user_name', data.user.name)
     const p = jwtDecode(data.token)
     setUser({ id: p.user_id, role: p.role, store_id: p.store_id, name: data?.user?.name || null })
+    if (p.exp) scheduleLogout(p.exp)
   }
 
   const register = async (payload) => { await api.post('/auth/register', payload) }
-
-  const logout = () => {
-    localStorage.removeItem('token')
-    localStorage.removeItem('user_name')
-    setUser(null)
-  }
 
   const value = useMemo(() => ({ user, hydrated, login, register, logout }), [user, hydrated])
   return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>


### PR DESCRIPTION
## Summary
- validate token expiration when loading stored auth state
- clear credentials and logout when token is expired
- schedule automatic logout based on token expiration

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 15 errors, 3 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c155d29fbc8320ba805710d977c1cf